### PR TITLE
getaddrinfo ENOTFOUND crash

### DIFF
--- a/lib/middleware/response-body.js
+++ b/lib/middleware/response-body.js
@@ -57,7 +57,11 @@ module.exports = function transformResponseBody(middleware, filter) {
         buf.push(data)
       }
 
-      var body = Buffer.concat(buf, length)
+      try {
+          var body = Buffer.concat(buf, length)
+      } catch (e) {
+          var body = ""
+      }
 
       // Expose the current body buffer
       res.body = res._originalBody = body


### PR DESCRIPTION
Temporary fix for getaddrinfo ENOTFOUND crash triggered by websites like http://www.cspplayground.com/compliant_examples?csp_mode=enable

Thank you,
Mark
```
Proxy error: { [Error: getaddrinfo ENOTFOUND example.iana.org example.iana.org:80]
  code: 'ENOTFOUND',
  errno: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'example.iana.org',
  host: 'example.iana.org',
  port: 80 }
buffer.js:237
    buf.copy(buffer, pos);
        ^

TypeError: buf.copy is not a function
  at Function.Buffer.concat (buffer.js:237:9)
  at ServerResponse.res.end (/home/epiloque/Dropbox/devel/smitman/node_modules/rocky/lib/middleware/response-body.js:60:25)
  at Object.exports.reply (/home/epiloque/Dropbox/devel/smitman/node_modules/rocky/lib/error.js:10:7)
  at resolver (/home/epiloque/Dropbox/devel/smitman/node_modules/rocky/lib/protocols/http/passes/forward.js:41:25)
  at finisher (/home/epiloque/Dropbox/devel/smitman/node_modules/rocky/lib/protocols/http/passes/forward.js:93:10)
  at ClientRequest.proxyError (/home/epiloque/Dropbox/devel/smitman/node_modules/http-proxy/lib/http-proxy/passes/web-incoming.js:138:9)
  at emitOne (events.js:82:20)
  at ClientRequest.emit (events.js:169:7)
  at Socket.socketErrorListener (_http_client.js:265:9)
  at emitOne (events.js:77:13)
  at Socket.emit (events.js:169:7)
  at connectErrorNT (net.js:996:8)
  at doNTCallback2 (node.js:450:9)
  at process._tickCallback (node.js:364:17)
```