### PR TITLE
support wildcard replacement in toPath middleware

### DIFF
--- a/lib/middleware/to-path.js
+++ b/lib/middleware/to-path.js
@@ -13,7 +13,7 @@ module.exports = function (path, args) {
       var reqWildcard = req.route.path.indexOf('*')
       var pathWildcard = newPath.indexOf('*')
       if (reqWildcard !== -1 && pathWildcard !== -1) {
-        newPath = newPath.replace('*', req.originalUrl.slice(req.route.path.indexOf('*')))
+        newPath = newPath.replace('*', req.originalUrl.slice(reqWildcard))
       }
     }
 

--- a/lib/middleware/to-path.js
+++ b/lib/middleware/to-path.js
@@ -8,6 +8,14 @@ module.exports = function (path, args) {
       path = path.replace(regex, value)
     })
 
+    if (req.route) {
+      var reqWildcard = req.route.path.indexOf('*')
+      var pathWildcard = path.indexOf('*')
+      if (reqWildcard !== -1 && pathWildcard !== -1) {
+        path = path.replace('*', req.originalUrl.slice(req.route.path.indexOf('*')))
+      }
+    }
+
     req.url = path
     next()
   }

--- a/lib/middleware/to-path.js
+++ b/lib/middleware/to-path.js
@@ -1,22 +1,23 @@
 module.exports = function (path, args) {
   return function (req, res, next) {
     const params = args || req.params || {}
+    var newPath = path
 
     Object.keys(params).forEach(function (param) {
       var value = params[param] || ''
       var regex = new RegExp('\:' + param, 'g')
-      path = path.replace(regex, value)
+      newPath = newPath.replace(regex, value)
     })
 
     if (req.route) {
       var reqWildcard = req.route.path.indexOf('*')
-      var pathWildcard = path.indexOf('*')
+      var pathWildcard = newPath.indexOf('*')
       if (reqWildcard !== -1 && pathWildcard !== -1) {
-        path = path.replace('*', req.originalUrl.slice(req.route.path.indexOf('*')))
+        newPath = newPath.replace('*', req.originalUrl.slice(req.route.path.indexOf('*')))
       }
     }
 
-    req.url = path
+    req.url = newPath
     next()
   }
 }

--- a/test/middleware/to-path.js
+++ b/test/middleware/to-path.js
@@ -61,4 +61,19 @@ suite('middleware#toPath', function () {
       done()
     })
   })
+
+  test('handling wildcard', function (done) {
+    var req = {
+      originalUrl: '/old-api/method-1',
+      route: { path: '/old-api/*' }
+    }
+    var newPath = '/new-api/*'
+    var mw = middleware.toPath(newPath)
+
+    mw(req, null, function assert (err) {
+      expect(err).to.be.undefined
+      expect(req.url).to.be.equal('/new-api/method-1')
+      done()
+    })
+  })
 })

--- a/test/middleware/to-path.js
+++ b/test/middleware/to-path.js
@@ -40,13 +40,18 @@ suite('middleware#toPath', function () {
 
   test('default previous params', function (done) {
     var req = { params: { id: 'chuck', action: 'update' } }
+    var req2 = { params: { id: 'chuck', action: 'delete' } }
     var newPath = '/profile/:id/:action'
     var mw = middleware.toPath(newPath)
 
     mw(req, null, function assert (err) {
       expect(err).to.be.undefined
       expect(req.url).to.be.equal('/profile/chuck/update')
-      done()
+      mw(req2, null, function assert (err) {
+        expect(err).to.be.undefined
+        expect(req2.url).to.be.equal('/profile/chuck/delete')
+        done()
+      })
     })
   })
 
@@ -67,13 +72,21 @@ suite('middleware#toPath', function () {
       originalUrl: '/old-api/method-1',
       route: { path: '/old-api/*' }
     }
+    var req2 = {
+      originalUrl: '/old-api/method-2',
+      route: { path: '/old-api/*' }
+    }
     var newPath = '/new-api/*'
     var mw = middleware.toPath(newPath)
 
     mw(req, null, function assert (err) {
       expect(err).to.be.undefined
       expect(req.url).to.be.equal('/new-api/method-1')
-      done()
+      mw(req2, null, function assert (err) {
+        expect(err).to.be.undefined
+        expect(req2.url).to.be.equal('/new-api/method-2')
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
I've wanted to impelement what tests say, but run into some weird issue. First request works fine, all the others don't. Seems not to be an issue of my implementation since modifying one of the original tests has the same behaviour.